### PR TITLE
Allow localOnly connections in IPv6 environment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,9 +21,12 @@ exports.register = function (pack, options, next) {
 
     var server = Net.createServer(function (socket) {
 
-        if (settings.localOnly && socket.address().address !== '127.0.0.1') {
-            socket.destroy();
-            return;
+        if (settings.localOnly) {
+            var address = socket.address();
+            if ((address.family === 'IPv6' && address.address !== '::1') || (address.family === 'IPv4' && address.address !== '127.0.0.1')) {
+                socket.destroy();
+                return;
+            }
         }
 
         var context = Hoek.applyToDefaults({ socket: socket, pack: pack }, options.context || {});


### PR DESCRIPTION
I was having a local connection rejected and tracked it down to the `localOnly` check being IPv4 specific when I was connecting via IPv6. I used `telnet localhost 9000` to connect which defaulted me to IPv6 on my mac. I believe this is also the issue @PavelPolyakov was likely having in #21.
