### PR TITLE
Allow passing repl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ The following options are available when configuring _'reptile'_:
 - `port` - the port to use to connect to the REPL.  Defaults to port 9000.
 - `localOnly` - determines if only traffic from localhost is allowed to connect to the REPL.  Defaults to true.
 - `context` - an object whose properties will be added to the REPL context
+- `replOptions` - an object whose properties will be passed along to `Repl.start`

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,12 +34,10 @@ exports.register = function (server, options, next) {
 
         const context = Hoek.applyToDefaults({ socket: socket, server: tcp }, options.context || {});
 
-        const repl = Repl.start({
-            input: socket,
-            output: socket,
-            terminal: true,
-            useGlobal: false
-        });
+        const replOptions = Hoek.applyToDefaults({ useGlobal: false, terminal: true }, settings.replOptions || {});
+        replOptions.input = socket;
+        replOptions.output = socket;
+        const repl = Repl.start(replOptions);
 
         repl.once('exit', () => {
 


### PR DESCRIPTION
I had a need to pass extra options to `Repl.start`.
