### PR TITLE
localOnly support for ipv6 format ::ffff:127.0.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ exports.register = function (server, options, next) {
 
         if (settings.localOnly) {
             const address = socket.address();
-            if ((address.family === 'IPv6' && address.address !== '::1') || (address.family === 'IPv4' && address.address !== '127.0.0.1')) {
+            if ((address.family === 'IPv6' && address.address !== '::1' && address.address !== '::ffff:127.0.0.1')
+            || (address.family === 'IPv4' && address.address !== '127.0.0.1')) {
                 socket.destroy();
                 return;
             }


### PR DESCRIPTION
My ip is received as `::ffff:127.0.0.1` when using `nc` or `telnet` to connect to reptile, failing to be accepted when using `localOnly` setting.