### PR TITLE
fix: closes all connections when stopped

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,34 @@ exports.register = async function (server, options) {
         barrier.pass();
     });
 
+    // Keep track of all connections
+    const sockets = []
+    tcp.on('connection', (socket) => {
+        
+        sockets.push(socket)
+    });
+
+    // Close all connections when Hapi server is stopped
+    server.ext({
+        type: 'onPreStop',
+        method: async () => {
+            
+            const teardownBarrier = new Barrier();
+
+            // Destroy all sockets
+            sockets.forEach((socket) => {
+                socket.end()
+            })
+            sockets.length = 0
+
+            // Close server
+            tcp.close(() => {
+                teardownBarrier.pass()
+            })
+            await teardownBarrier
+        }
+    });
+
     tcp.listen(settings.port);
     await barrier;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Net = require('net');
+const Util = require('util');
 const Repl = require('repl');
 const Barrier = require('cb-barrier');
 const Hoek = require('hoek');
@@ -57,30 +58,31 @@ exports.register = async function (server, options) {
     });
 
     // Keep track of all connections
-    const sockets = []
+    const sockets = [];
     tcp.on('connection', (socket) => {
-        
-        sockets.push(socket)
+
+        sockets.push(socket);
+        socket.once('close', () => {
+
+            sockets.splice(sockets.indexOf(socket), 1);
+        });
     });
 
     // Close all connections when Hapi server is stopped
     server.ext({
-        type: 'onPreStop',
+        type: 'onPostStop',
         method: async () => {
-            
-            const teardownBarrier = new Barrier();
 
-            // Destroy all sockets
-            sockets.forEach((socket) => {
-                socket.end()
-            })
-            sockets.length = 0
+            // Close server (which keeps existing connections)
+            Util.promisify(tcp.close.bind(tcp))();
 
-            // Close server
-            tcp.close(() => {
-                teardownBarrier.pass()
-            })
-            await teardownBarrier
+            // Close all sockets
+            await Promise.all(sockets.map((socket) => {
+
+                return Util.promisify(socket.end.bind(socket))('\n', 'utf8');
+            }));
+
+            return null;
         }
     });
 


### PR DESCRIPTION
This fix closes all connections when the Hapi server is stopped. Otherwise the node process will continue running until the last connection was closed.